### PR TITLE
Support default expressions

### DIFF
--- a/examples/expression.rs
+++ b/examples/expression.rs
@@ -1,0 +1,18 @@
+use inline_tweak::tweak;
+use std::time::Duration;
+
+fn counter() -> i32 {
+    static mut N: i32 = 0;
+    unsafe {
+        N += 1;
+        N
+    }
+}
+
+fn main() {
+    loop {
+        // Try removing or changing the value while the application is running
+        println!("{}", tweak!(100; counter()));
+        std::thread::sleep(Duration::from_millis(500));
+    }
+}


### PR DESCRIPTION
This PR adds support for default expressions.

For example, `tweak!(rng.gen_range(0.0, 1.0))` has a default expression of `rng.gen_range(0.0, 1.0)` and a tweak value of `None`. This means that when the tweak is called, it'll evaluate its default expression. If the code is changed to `tweak!(0.5; rng.gen_range(0.0, 1.0))` while the program is running, then the tweak will get a new tweak value of `Some(0.5)`, which will take precedence over the default expression (so the default expression won't be evaluated). If the tweak value is removed, it'll go back to being `None`, and the default expression will take over again.

If instead the program starts with `tweak!(0.5; rng.gen_range(0.0, 1.0))`, the initial tweak value will be `Some(0.5)`, and modifying the file will work as before.

The tweak value is considered `None` if parsing to `T` fails.