### PR TITLE
Derive negation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,13 @@ lazy_static = "1.4.0"
 rustc-hash = "1.1.0"
 
 # Derive
-inline_tweak_derive = { version = "3.0.0", optional = true }
-syn = { version = "2.0", optional = true, default-features = false, features = ["parsing", "full", "visit"]}
+# inline_tweak_derive = { version = "3.0.0", optional = true }
+inline_tweak_derive = { path = "inline_tweak_derive", optional = true }
+syn = { version = "2.0", optional = true, default-features = false, features = ["parsing", "printing", "full", "visit"]}
 proc-macro2 = { version = "1.0", optional = true, default-features = false, features = ["span-locations"]}
 
 [features]
-default = []
+default = ["derive"]
 release_tweak = []
 derive = ["dep:syn", "dep:proc-macro2", "dep:inline_tweak_derive"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,12 @@ lazy_static = "1.4.0"
 rustc-hash = "1.1.0"
 
 # Derive
-# inline_tweak_derive = { version = "3.0.0", optional = true }
-inline_tweak_derive = { path = "inline_tweak_derive", optional = true }
+inline_tweak_derive = { version = "3.0.0", optional = true }
 syn = { version = "2.0", optional = true, default-features = false, features = ["parsing", "printing", "full", "visit"]}
 proc-macro2 = { version = "1.0", optional = true, default-features = false, features = ["span-locations"]}
 
 [features]
-default = ["derive"]
+default = []
 release_tweak = []
 derive = ["dep:syn", "dep:proc-macro2", "dep:inline_tweak_derive"]
 


### PR DESCRIPTION
Supports adding and removing unary negations for integers and floats for `inline_tweak::tweak_fn`.