### PR TITLE
Removed the lazy_static dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ categories = [
 repository = "https://github.com/Uriopass/inline_tweak"
 
 [dependencies]
-lazy_static = "1.4.0"
 rustc-hash = "2.1.0"
 
 # Derive

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ by tuxedo labs.
 Tweak any literal directly from your code, changes to the source appear while running the program.  
 It works by parsing the file when a change occurs.  
 
-The library is minimal, only requiring the `lazy_static` dependency to hold modified values.  
 In release mode, the tweaking code is disabled and compiled away.
 
 The `derive` feature exposes a proc macro to turn all literals from a function body into tweakable values.


### PR DESCRIPTION
Removed the `lazy_static` dependency and replaced it with `std::sync::LazyLock` as per https://github.com/rust-lang-nursery/lazy-static.rs?tab=readme-ov-file#standard-library

The only reason I see not to merge this is it does bump the MSRV to 1.80. If that is undesirable you may want to delay this PR.