### PR TITLE
replace f32 and f64 before parsing float

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ mod itweak {
             $(
             impl Tweakable for $t {
                 fn parse(x: &str) -> Option<$t> {
-                    let v = x.replace("_", "");
+                    let v = x.replace("_", "").replace(stringify!($t), "");
                     FromStr::from_str(&v).ok()
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ mod itweak {
             $(
             impl Tweakable for $t {
                 fn parse(x: &str) -> Option<$t> {
-                    let s = x.replace("_", "");
+                    let s = x.replace("_", "").replace(stringify!($t), "");
                     let radix = if s.starts_with("0x") {
                         16
                     } else if s.starts_with("0o") {


### PR DESCRIPTION
currently the f32 and f64 suffix syntax for floats is unsupported in the float parser, this adds support for it. take for example 2.0 being valid while 2f32 not being.